### PR TITLE
feat: add tentative order API

### DIFF
--- a/BackendUsuarios/app.js
+++ b/BackendUsuarios/app.js
@@ -5,6 +5,7 @@ const connectDB = require('./utils/db');
 const userRoutes = require('./routes/userRoutes');
 const sessionRoutes = require("./routes/sessionRoutes");
 const dataSessionRoutes = require("./routes/dataSessionRoutes");
+const orderRoutes = require("./routes/orderRoutes");
 const cors = require('cors');
 
 app.use(express.json());
@@ -13,6 +14,7 @@ app.use(cors());
 app.use('/usuarios', userRoutes);
 app.use("/session", sessionRoutes);
 app.use("/data-session", dataSessionRoutes);
+app.use("/orders", orderRoutes);
 
 connectDB();
 

--- a/BackendUsuarios/models/orderModel.js
+++ b/BackendUsuarios/models/orderModel.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const itemSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  description: { type: String },
+  color: { type: String },
+  size: { type: String },
+  quantity: { type: Number, default: 1 },
+}, { _id: false });
+
+const orderSchema = new mongoose.Schema({
+  sessionId: { type: String },
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  items: { type: [itemSchema], required: true },
+  status: { type: String, default: 'tentative' },
+  createdAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('Order', orderSchema);

--- a/BackendUsuarios/routes/orderRoutes.js
+++ b/BackendUsuarios/routes/orderRoutes.js
@@ -1,0 +1,32 @@
+const express = require("express");
+const router = express.Router();
+const Order = require("../models/orderModel");
+
+// Create a tentative order
+router.post("/", async (req, res) => {
+  try {
+    const { sessionId, userId, items } = req.body;
+    if (!items || !Array.isArray(items) || items.length === 0) {
+      return res.status(400).json({ error: "Items are required" });
+    }
+    const order = new Order({ sessionId, userId, items });
+    await order.save();
+    res.status(201).json(order);
+  } catch (error) {
+    console.error("Error creating order:", error);
+    res.status(500).json({ error: "Error creating order" });
+  }
+});
+
+// Retrieve orders by sessionId
+router.get("/:sessionId", async (req, res) => {
+  try {
+    const orders = await Order.find({ sessionId: req.params.sessionId });
+    res.json(orders);
+  } catch (error) {
+    console.error("Error fetching orders:", error);
+    res.status(500).json({ error: "Error fetching orders" });
+  }
+});
+
+module.exports = router;

--- a/InteractiveAvatar/app/api/orders/route.ts
+++ b/InteractiveAvatar/app/api/orders/route.ts
@@ -1,0 +1,15 @@
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const res = await fetch("http://localhost:5000/orders", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return new Response(JSON.stringify(data), { status: res.status });
+  } catch (error) {
+    console.error("Error forwarding order:", error);
+    return new Response("Error creating order", { status: 500 });
+  }
+}

--- a/InteractiveAvatar/components/ProductFormPanel.tsx
+++ b/InteractiveAvatar/components/ProductFormPanel.tsx
@@ -4,31 +4,42 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 
-const productImages = [
-    {
-      src: "/images/product1.jpg",
-      link: "https://example.com/product1",
-      alt: "Producto 1",
-      title: "Producto 1",
-      description: "Descripción del Producto 1",
-    },
-    {
-      src: "/images/product2.jpg",
-      link: "https://example.com/product2",
-      alt: "Producto 2",
-      title: "Producto 2",
-      description: "Descripción del Producto 2",
-    },
-    {
-      src: "/images/product3.jpg",
-      link: "https://example.com/product3",
-      alt: "Producto 3",
-      title: "Producto 3",
-      description: "Descripción del Producto 3",
-    },
-  ];
+export type ProductSelection = {
+  title: string;
+  description: string;
+  color: string;
+  size: string;
+};
 
-export default function ProductFormPanel() {
+interface ProductFormPanelProps {
+  onAdd?: (product: ProductSelection) => void;
+}
+
+const productImages = [
+  {
+    src: "/images/product1.jpg",
+    link: "https://example.com/product1",
+    alt: "Producto 1",
+    title: "Producto 1",
+    description: "Descripción del Producto 1",
+  },
+  {
+    src: "/images/product2.jpg",
+    link: "https://example.com/product2",
+    alt: "Producto 2",
+    title: "Producto 2",
+    description: "Descripción del Producto 2",
+  },
+  {
+    src: "/images/product3.jpg",
+    link: "https://example.com/product3",
+    alt: "Producto 3",
+    title: "Producto 3",
+    description: "Descripción del Producto 3",
+  },
+];
+
+export default function ProductFormPanel({ onAdd }: ProductFormPanelProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [selectedColor, setSelectedColor] = useState("");
@@ -44,40 +55,39 @@ export default function ProductFormPanel() {
       {/* Miniaturas como slider básico */}
       <div className="flex gap-2 overflow-x-auto">
         {productImages.map((item, idx) => (
-            <div
+          <div
             key={idx}
             onMouseEnter={() => {
-                setTitle(item.title);
-                setDescription(item.description);
+              setTitle(item.title);
+              setDescription(item.description);
             }}
-            >
-            <Link href={item.link} legacyBehavior>
-                <a target="_blank" rel="noopener noreferrer">
+          >
+            <Link legacyBehavior href={item.link}>
+              <a href={item.link} rel="noopener noreferrer" target="_blank">
                 <Image
-                    src={item.src}
-                    alt={item.alt}
-                    width={80}
-                    height={80}
-                    className="rounded-lg hover:scale-105 transition-transform"
+                  alt={item.alt}
+                  className="rounded-lg hover:scale-105 transition-transform"
+                  height={80}
+                  src={item.src}
+                  width={80}
                 />
-                </a>
+              </a>
             </Link>
-            </div>
+          </div>
         ))}
-        </div>
-
+      </div>
 
       <input
-        type="text"
-        placeholder="Nombre del producto"
         className="px-3 py-2 rounded bg-gray-800 border border-gray-700"
+        placeholder="Nombre del producto"
+        type="text"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
 
       <textarea
-        placeholder="Descripción"
         className="px-3 py-2 rounded bg-gray-800 border border-gray-700"
+        placeholder="Descripción"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
       />
@@ -104,7 +114,17 @@ export default function ProductFormPanel() {
         ))}
       </select>
 
-      <button className="mt-2 bg-blue-600 hover:bg-blue-700 transition-colors px-4 py-2 rounded">
+      <button
+        className="mt-2 bg-blue-600 hover:bg-blue-700 transition-colors px-4 py-2 rounded"
+        onClick={() =>
+          onAdd?.({
+            title,
+            description,
+            color: selectedColor,
+            size: selectedSize,
+          })
+        }
+      >
         Agregar al Carrito
       </button>
     </div>

--- a/InteractiveAvatar/components/VendedorInteractivo.tsx
+++ b/InteractiveAvatar/components/VendedorInteractivo.tsx
@@ -1,0 +1,127 @@
+import type { StartAvatarResponse } from "@heygen/streaming-avatar";
+
+import { useEffect, useRef, useState } from "react";
+import StreamingAvatar, {
+  AvatarQuality,
+  StreamingEvents,
+} from "@heygen/streaming-avatar";
+
+import ProductFormPanel, { ProductSelection } from "./ProductFormPanel";
+
+import { detectarUrlDesdeMensaje } from "@/app/utils/detectarUrlDesdeMensaje";
+
+interface CartItem extends ProductSelection {}
+
+export default function VendedorInteractivo() {
+  const [stream, setStream] = useState<MediaStream>();
+  const [data, setData] = useState<StartAvatarResponse>();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const avatar = useRef<StreamingAvatar | null>(null);
+  const [showPanel, setShowPanel] = useState(false);
+  const [cart, setCart] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    if (videoRef.current && stream) {
+      videoRef.current.srcObject = stream;
+    }
+  }, [stream]);
+
+  useEffect(() => {
+    return () => {
+      avatar.current?.stop();
+      avatar.current?.close();
+    };
+  }, []);
+
+  async function fetchAccessToken() {
+    const res = await fetch("/api/get-access-token", { method: "POST" });
+
+    return res.text();
+  }
+
+  async function startSession() {
+    const token = await fetchAccessToken();
+
+    avatar.current = new StreamingAvatar({ token });
+
+    avatar.current.on(StreamingEvents.STREAM_READY, (e) => {
+      setStream(e.detail);
+    });
+
+    avatar.current.on(StreamingEvents.USER_TALKING_MESSAGE, (e) => {
+      const msg = e.detail.message;
+      const url = detectarUrlDesdeMensaje(msg);
+
+      if (url) {
+        setShowPanel(true);
+      }
+    });
+
+    const res = await avatar.current.createStartAvatar({
+      quality: AvatarQuality.Low,
+      avatarName: "Ann_Therapist_public",
+    });
+
+    setData(res);
+    await avatar.current.startVoiceChat({ isInputAudioMuted: false });
+  }
+
+  const handleAddProduct = (product: CartItem) => {
+    setCart((prev) => [...prev, product]);
+  };
+
+  const handleFinalizeOrder = async () => {
+    try {
+      await fetch("/api/orders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ items: cart }),
+      });
+      setCart([]);
+      setShowPanel(false);
+    } catch (e) {
+      console.error("Error creating order", e);
+    }
+  };
+
+  return (
+    <div className="flex gap-4">
+      <div className="flex-1 flex flex-col items-center">
+        <video
+          ref={videoRef}
+          autoPlay
+          muted
+          playsInline
+          className="w-full max-w-xl bg-black"
+        />
+        {!data && (
+          <button
+            className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
+            onClick={startSession}
+          >
+            Iniciar sesión
+          </button>
+        )}
+      </div>
+      {showPanel && <ProductFormPanel onAdd={handleAddProduct} />}
+      {cart.length > 0 && (
+        <div className="w-[300px] p-4 bg-gray-800 text-white rounded flex flex-col gap-2">
+          <h3 className="text-lg font-bold">Pedido Tentativo</h3>
+          <ul className="flex-1 overflow-y-auto">
+            {cart.map((item, idx) => (
+              <li key={idx} className="text-sm">
+                {item.title} - {item.color} {item.size}
+              </li>
+            ))}
+          </ul>
+          <button
+            className="mt-2 bg-blue-600 hover:bg-blue-700 transition-colors px-4 py-2 rounded"
+            onClick={handleFinalizeOrder}
+          >
+            Finalizar pedido
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Mongoose `Order` model with items and status
- expose `/orders` endpoint in backend to create and list tentative orders
- forward front-end order submissions to backend via Next.js API route

## Testing
- `npm test` (BackendUsuarios) *(fails: Missing script "test")*
- `npm run lint` (BackendUsuarios) *(fails: Missing script "lint")*
- `npm test` (InteractiveAvatar) *(fails: Missing script "test")*
- `npm run lint -- --no-fix`

------
https://chatgpt.com/codex/tasks/task_e_68ab717c628c832aa11682c0ad7b0566